### PR TITLE
Stopping timers thread and preventing epicsIO race condition

### DIFF
--- a/smlib/fsm.py
+++ b/smlib/fsm.py
@@ -24,9 +24,11 @@ class fsmBase(threading.Thread):
         super(fsmBase, self).__init__(name=name)
         self._name = name
         if 'tmgr' not in args:
+            self._private_tmgr = True
             self._tmgr = fsmTimers()
             self._tmgr.start()
         else:
+            self._private_tmgr = False
             self._tmgr = args['tmgr']
             if not self._tmgr.is_alive():
                 self._tmgr.start()
@@ -185,6 +187,8 @@ class fsmBase(threading.Thread):
         self._cond.notify()
         self._cond.release()
         self.join()
+        if self._private_tmgr:
+            self._tmgr.kill()
 
     def trigger(self, **args) -> None:
         '''Enqueue an event to be processed by the FSM'''

--- a/smlib/io.py
+++ b/smlib/io.py
@@ -30,8 +30,8 @@ class epicsIO():
         self._conn = False  # keeps all infos arriving with connection callback
 
         self._attached = set()  # set of finite state machines using this IO
-        self._pv = epics.PV(name, callback=self.chgcb, connection_callback=self.concb, auto_monitor=True)
         self._cond = threading.Condition()
+        self._pv = epics.PV(name, callback=self.chgcb, connection_callback=self.concb, auto_monitor=True)
 
     def ioname(self) -> str:
         '''Return the name of the PV.'''


### PR DESCRIPTION
Both problems we observed while experimenting with the library.

I was not using the loader interface.

The `epicsIO` race condition appeared after the fsm was started, stopped and then restarted.
