### PR TITLE
Obtain PV control values for the purpose of setting enum strings.

### DIFF
--- a/smlib/fsm.py
+++ b/smlib/fsm.py
@@ -59,10 +59,10 @@ class fsmBase(threading.Thread):
         self._awakerReason = ""
         self._watchdog = None
 
-    # populate the sensityvity list for each state
+    # populate the sensitivity list for each state
     def setSensLists(self, statesWithIos: dict) -> None:
-        # statesWithIos e un dizionario in cui la chiave e il nome dello stato e
-        # il valore un array di ingressi utilizzati dallo stato
+        # statesWithIos is a dictionary in which the key is the name of the state
+        # and the value an array of epicsIO inputs used by the state
         for state, iolist in statesWithIos.items():
             iodict = {}
             for io in iolist:
@@ -91,11 +91,11 @@ class fsmBase(threading.Thread):
             return
         self._nextstatename = state
         self._nextstateargs = (args, kwargs)
-        # metodo eval del prossimo stato
+        # next state's eval method
         self._nextstate = getattr(self, '%s_eval' % state)
-        # metodo entry del prossimo stato
+        # next state's entry method
         self._nextentry = getattr(self, '%s_entry' % state, None)
-        # metodo exit del prossimo stato
+        # next state's exit method
         self._nextexit = getattr(self, '%s_exit' % state, None)
 
     def gotoPrevState(self, *args, **kwargs) -> None:
@@ -162,11 +162,11 @@ class fsmBase(threading.Thread):
     def eval_forever(self) -> None:
         '''Main loop of the FSM'''
         while not self._stop_thread:
-            changed = self.eval()  # eval viene eseguito senza lock
-            self.lock()  # blocca la coda degli eventi
+            changed = self.eval()  # eval runs without lock
+            self.lock()  # block on the queue for events
             if not changed and len(self._events) == 0:
                 self.logD("No events to process going to sleep\n")
-                self._cond.wait()  # la macchina va in sleep in attesa di un evento (da un IO, timer...)
+                self._cond.wait()  # go to sleep waiting for an event (from an IO, timer ...)
                 self.logD('awoken')
             self._process_one_event()  # PROCESS ONLY IF RETURN TRUE?
             self.unlock()

--- a/smlib/fsm.py
+++ b/smlib/fsm.py
@@ -134,6 +134,8 @@ class fsmBase(threading.Thread):
     def eval(self) -> bool:
         '''Execute the current state'''
         changed = False
+        if self._nextstate is None and self._curstate is None:
+            return False
         if self._nextstate != self._curstate:
             self.logD('%s => %s' % (self._curstatename, self._nextstatename))
             self._prevstatename = self._curstatename

--- a/smlib/io.py
+++ b/smlib/io.py
@@ -114,6 +114,9 @@ class epicsIO():
         '''Return True if the PV is connected.'''
         return self._conn
 
+    def get_ctrlvars(self) -> bool:
+        '''Return PV control variables.'''
+        return self._pv.get_ctrlvars()
 
 class fsmIOs():
     '''Class representing a list of epicsIO objects.'''
@@ -527,6 +530,10 @@ class fsmIO():
 
     def enumStrings(self) -> list:
         '''Possible string values of enum PV'''
+        if self._data.get('enum_strs', None) is None:
+            ctrlvars = self._reflectedIO.get_ctrlvars()
+            if ctrlvars and 'enum_strs' in ctrlvars:
+               self._data['enum_strs'] = ctrlvars['enum_strs']
         return self._data.get('enum_strs', None)
     
     def displayLimits(self) -> tuple:

--- a/smlib/loader.py
+++ b/smlib/loader.py
@@ -63,22 +63,23 @@ class loader(object):
         for fsm in self._fsmsList:
             if fsm.is_alive():
                 fsm.kill()
+                print("Killed fsm", fsm)
         print("Killed all the fsms")
         if self._timerManager.is_alive():  # if no fsm is loaded it won't be alive
             self._timerManager.kill()
+            print("Killed the timer manager", self._timerManager)
         print("Killed the timer manager")
 
     def printUnconnectedIOs(self, signum, frame): # pylint: disable=unused-argument
         '''Print all the unconnected IOs.'''
         ios = self._ioManager.getAll()
         s = 0
-        print("DISCONNECTED INPUTS:")
+        print("DISCONNECTED INPUTS (ios %s):" % self._ioManager)
         for i in ios:
             if not i.connected():
                 print(i.ioname())
                 s += 1
         print("Total disconnected inputs: %d out of %d!" % (s, len(ios)))
-        signal.pause()
 
     def start(self, blocking=True):
         '''Start all the loaded fsms.'''


### PR DESCRIPTION
I'm seeing `self._data['enum_strs']` being set to `None` if I call `enumStrings()` after the enum PV received a value update. I got this explanation from `pyepics` https://github.com/pyepics/pyepics/issues/276.

For me, the problem is solved by this PR, for example:

```
if self.isIoConnected() and self.isIoInitialized():
    self.pv_mode.enumStrings()
```